### PR TITLE
Remove unexisting Laminas ConfigProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,11 +55,6 @@
         "psalm": "psalm",
         "infection": "XDEBUG_MODE=coverage roave-infection-static-analysis-plugin"
     },
-    "extra": {
-        "laminas": {
-            "config-provider": "Pheature\\Core\\Toggle\\Container\\ConfigProvider"
-        }
-    },
     "config": {
         "sort-packages": true
     }


### PR DESCRIPTION
Due to we removed the `ConfigProvider` we still need to remove the reference from the `composer.json`