### PR TITLE
Coding style via PHP_CodeSniffer & assertion call

### DIFF
--- a/src/Exception/InvalidStrategyTypeGiven.php
+++ b/src/Exception/InvalidStrategyTypeGiven.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 
 final class InvalidStrategyTypeGiven extends InvalidArgumentException
 {
-
     public static function withType(string $strategyType): self
     {
         return new self(sprintf('Unknown toggle strategy type %s given.', $strategyType));

--- a/test/Read/ChainFeatureFinderTest.php
+++ b/test/Read/ChainFeatureFinderTest.php
@@ -63,7 +63,7 @@ class ChainFeatureFinderTest extends TestCase
 
         $actual = $chain->get(self::FEATURE_ID);
 
-        self::assertSame($expectedFeature, $actual);
+        $this->assertSame($expectedFeature, $actual);
     }
 
     public function testItShouldGetTheFeatureByFeatureIdFromTheSecondFinder(): void
@@ -89,7 +89,7 @@ class ChainFeatureFinderTest extends TestCase
 
         $actual = $chain->get(self::FEATURE_ID);
 
-        self::assertSame($expectedFeature, $actual);
+        $this->assertSame($expectedFeature, $actual);
     }
 
     public function testItShouldReturnAllFeaturesFromAllFinders(): void
@@ -125,7 +125,7 @@ class ChainFeatureFinderTest extends TestCase
 
         $actual = $chain->all();
 
-        self::assertCount(count($expectedFeatures), $actual);
+        $this->assertCount(count($expectedFeatures), $actual);
     }
 
     public function testItShouldReturnAllFeaturesFromAllFindersWithoutRepeatingItems(): void
@@ -161,7 +161,7 @@ class ChainFeatureFinderTest extends TestCase
 
         $actual = $chain->all();
 
-        self::assertCount(count($expectedFeatures), $actual);
+        $this->assertCount(count($expectedFeatures), $actual);
     }
 
     public function testItShouldReturnAllFeaturesFromAllFindersOrderedByFirstFinderFirst(): void
@@ -197,7 +197,7 @@ class ChainFeatureFinderTest extends TestCase
 
         $actual = $chain->all();
 
-        self::assertSame($expectedFeatures, $actual);
+        $this->assertSame($expectedFeatures, $actual);
     }
 
     public function testItShouldReturnAnEmptyArrayIfNoFeaturesFoundInFinders(): void
@@ -221,6 +221,6 @@ class ChainFeatureFinderTest extends TestCase
 
         $actual = $chain->all();
 
-        self::assertSame([], $actual);
+        $this->assertSame([], $actual);
     }
 }

--- a/test/Read/ChainSegmentFactoryTest.php
+++ b/test/Read/ChainSegmentFactoryTest.php
@@ -42,7 +42,7 @@ final class ChainSegmentFactoryTest extends TestCase
 
         $current = $chainSegmentFactory->create(self::SEGMENT_ID, self::SEGMENT_TYPE, self::PAYLOAD);
 
-        self::assertSame($expectedSegment, $current);
-        self::assertSame([self::SEGMENT_TYPE], $chainSegmentFactory->types());
+        $this->assertSame($expectedSegment, $current);
+        $this->assertSame([self::SEGMENT_TYPE], $chainSegmentFactory->types());
     }
 }

--- a/test/Read/ChainToggleStrategyFactoryTest.php
+++ b/test/Read/ChainToggleStrategyFactoryTest.php
@@ -63,8 +63,8 @@ final class ChainToggleStrategyFactoryTest extends TestCase
             'segments' => []
         ]);
 
-        self::assertSame($expectedStrategy, $current);
-        self::assertSame([self::STRATEGY_TYPE], $chainToggleStrategyFactory->types());
+        $this->assertSame($expectedStrategy, $current);
+        $this->assertSame([self::STRATEGY_TYPE], $chainToggleStrategyFactory->types());
     }
 
     public function testItShouldBeCreatedWithAtLeastOneToggleStrategyFactoryInstanceAndSegments(): void
@@ -91,8 +91,7 @@ final class ChainToggleStrategyFactoryTest extends TestCase
             'segments' => self::SEGMENTS
         ]);
 
-        self::assertSame($expectedStrategy, $current);
-        self::assertSame([self::STRATEGY_TYPE, 'other_type'], $chainToggleStrategyFactory->types());
+        $this->assertSame($expectedStrategy, $current);
+        $this->assertSame([self::STRATEGY_TYPE, 'other_type'], $chainToggleStrategyFactory->types());
     }
 }
-    


### PR DESCRIPTION
# Changed log

- To be consistency, using the `$this` to make all assertion methods call on PHP files.
- Fixing coding style via PHP_CodeSniffer.